### PR TITLE
Fix author affiliation attribute in lib.typ

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -24,7 +24,7 @@
     (
       name: "First Last",
       role: none,
-      organization: none,
+      affiliation: none,
       location: none,
       email: none
     ),
@@ -204,8 +204,8 @@
           if "role" in author [
             \ #author.role
           ]
-          if "organization" in author [
-            \ #author.organization
+          if "affiliation" in author [
+            \ #author.affiliation
           ]
           if "email" in author [
             \ #author.email


### PR DESCRIPTION
This PR fixes the `affiliation` attribute of the `authors` settings.  

**Problem**: The affiliation is not shown in the rendered PDF.
There is a mismatch of the variable names  `organization` and `affiliation`.

**Solution**: Renaming the variable `organization` to `affiliation` in `lib.typ`